### PR TITLE
Adjustments to the deployment page on smaller sized browsers

### DIFF
--- a/src/pages/DeploymentPage/DeploymentPage.jsx
+++ b/src/pages/DeploymentPage/DeploymentPage.jsx
@@ -83,11 +83,6 @@ const DivFlexStyled = styled.div`
   justify-content: space-between;
   margin-top: 1.5em;
 `
-const FormGroupStyled = styled(FormGroup)`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-`
 
 /**
  * Define constants to match the action state


### PR DESCRIPTION
Deployment page section is unreadable on smaller sized screens, page needs to accommodate for smaller sized screens. 