### PR TITLE
FogBugz 3360 - Tidy up Permission Page by hiding Import Account Section if there are no accounts to import

### DIFF
--- a/src/pages/PermissionPage/components/Permissionlist/Permissionlist.jsx
+++ b/src/pages/PermissionPage/components/Permissionlist/Permissionlist.jsx
@@ -220,7 +220,8 @@ const Permissionlist = (props) => {
                                   </PermissionTable>
                                 </CardBody>
                               </FirstCardStyled>                              
-                                <FirstCardStyled>
+                              { (importAccountsList && numberOfImportAccounts > 0) 
+                                ? <FirstCardStyled>
                                   <CardHeaderStyled>Import Account</CardHeaderStyled>
                                   <CardBody>
                                     <InfoDivStyled>
@@ -232,8 +233,7 @@ const Permissionlist = (props) => {
                                     </InfoDivStyled>
                                     <PermissionTable borderless>
                                     {
-                                      (importAccountsList && numberOfImportAccounts > 0) 
-                                      ? Object.keys(importAccountsList).map((account) => (
+                                        Object.keys(importAccountsList).map((account) => (
                                         (importAccountsList[account] &&
                                           importAccountsList[account].length === 2 && 
                                           !importAccountsList[account][0].private_key &&
@@ -277,18 +277,12 @@ const Permissionlist = (props) => {
                                           </tr>
                                         </tbody>
                                       ))
-                                      : <tbody>
-                                        <tr>
-                                          <td width="100%" style={{textAlign:"center"}}>
-                                            <strong>No accounts available</strong>
-                                          </td>
-                                        </tr>
-                                      </tbody>
                                     }
                                   </PermissionTable>
                                   </CardBody>
                                 </FirstCardStyled>
-                                
+                                : null
+                              }
                               </div>
               }
       </div>


### PR DESCRIPTION
Changes
---
* (3360) - Hide the entire Import Account Section panel instead of displaying a message if there are no accounts to import. If there are accounts to import, then the panel will be visible with the list of accounts that could be imported. 