### PR TITLE
Fix drag and drop code viewer accepting .json files

### DIFF
--- a/src/components/DragDropCodeViewer/DragDropCodeViewer.jsx
+++ b/src/components/DragDropCodeViewer/DragDropCodeViewer.jsx
@@ -137,7 +137,7 @@ class DragDropCodeViewer extends Component {
       <>
         <div className={"dragDropCodeViewerContainer " + (this.state.value && this.state.value !== "" ? "hasFileData" : "")} >
           <Dropzone onDrop={([file]) => this.onDrop(file)} 
-            accept={'application/json, .cpp'} 
+            accept={'.cpp'} 
             >
             {({getRootProps, getInputProps}) => (
               <section className="dropzone">


### PR DESCRIPTION
Removed `application/json` as acceptable file type for drag and drop code viewer