### PR TITLE
Fogbugz 3403 - Action history filter fix

### DIFF
--- a/src/pages/ActionlistPage/components/Actionlist/Actionlist.jsx
+++ b/src/pages/ActionlistPage/components/Actionlist/Actionlist.jsx
@@ -78,7 +78,7 @@ const Actionlist = (props) => {
                 </thead>
                 <tbody className="hashText">
                   {payload.length < 1
-                    ? <tr><td colSpan="3" className="text-center">No actions found{smartContractName && ` for ${smartContractName}`}</td></tr>
+                    ? <tr><td colSpan="3" className="text-center">No actions found{smartContractName && ` with Smart Contract name ${smartContractName}`}</td></tr>
                     : payload.map((action, index)=>
                       <tr onClick={evt=>props.push(`/action/${action.block_num}/${action.receipt.global_sequence}`)} key={index}>
                         <td>{action.act.account}</td>

--- a/src/pages/PushactionPage/components/Actionhistory.jsx
+++ b/src/pages/PushactionPage/components/Actionhistory.jsx
@@ -99,7 +99,7 @@ const Actionhistory = (props) => {
                 </thead>
                 <tbody>
                   {actionsList.length < 1 ?
-                    <tr><td colSpan="5" className="text-center">No actions could be found{filter.smartContractName && ` for ${filter.smartContractName}` }</td></tr>
+                    <tr><td colSpan="5" className="text-center">No actions found{filter.smartContractName && ` with Smart Contract name ${filter.smartContractName}` }</td></tr>
                   : actionsList.map((action, index)=>
                     <tr key={index} data-globalsequence={action.receipt.global_sequence}>
                       <TdStyled>{action.act.account}</TdStyled>


### PR DESCRIPTION
- Removed check for actionsList length from action history filter. Filter and record count dropdowns now appear even if actionsList length is 0. This prevents users causing the filter to disappear by selecting a smart contract with no historical actions.
- Updated Action History and Actions List page error messages to include user selected smart contract name filter.