### PR TITLE
Fixed issue where permission page breaks when connected to mainnet

### DIFF
--- a/src/pages/PermissionPage/components/Permissionlist/Permissionlist.jsx
+++ b/src/pages/PermissionPage/components/Permissionlist/Permissionlist.jsx
@@ -127,8 +127,10 @@ const Permissionlist = (props) => {
     let _permissionTwoCorrect = false;
 
     if (permissionList.length > 0) {
-      _permissionOneCorrect = permissionList[0].permission === 'owner' || permissionList[0].permission === 'active';
-      _permissionTwoCorrect = permissionList[1].permission === 'owner' || permissionList[1].permission === 'active';
+      _permissionOneCorrect = (permissionList[0]) ?
+        (permissionList[0].permission === 'owner' || permissionList[0].permission === 'active') : false;
+      _permissionTwoCorrect = (permissionList[1]) ?
+        (permissionList[1].permission === 'owner' || permissionList[1].permission === 'active') : false;
     }
 
     return _permissionOneCorrect && _permissionTwoCorrect;


### PR DESCRIPTION
:warning: - The bug occurs when connected to the mainnet and the database call retrieves an account which has only owner key and an undefined second permission.

This breaks the permission page because it expects the account to have 2 or more permissions, but doesn't properly check for the case where it has only 1 permission.

In other words, the problem is due to poor implementation lacking the guard