### PR TITLE
Fogbugz 3374 - Actions List timeout fix

### DIFF
--- a/src/pages/ActionlistPage/components/Actionlist/Actionlist.jsx
+++ b/src/pages/ActionlistPage/components/Actionlist/Actionlist.jsx
@@ -58,9 +58,9 @@ const Actionlist = (props) => {
       </Row>
       <Row>
         <Col xs="12">
-        { error ?
+        { (error && error.status.name !== "AjaxTimeoutError") ?
           <>
-            {!isObjectEmpty(error) && <p className="text-danger">{JSON.stringify(error)}</p>}
+            {!isObjectEmpty(error) && <p className="text-danger">{JSON.stringify(error.status.message)}</p>}
             <ErrorButton onClick={props.fetchStart}>Connection error, click to reload</ErrorButton>
           </>
         : isFetching ? (

--- a/src/pages/ActionlistPage/components/Actionlist/ActionlistReducer.js
+++ b/src/pages/ActionlistPage/components/Actionlist/ActionlistReducer.js
@@ -47,7 +47,7 @@ const fetchEpic = ( action$, state$ ) => action$.pipe(
       map(res => fetchFulfilled(res.response)),
       catchError(error => {
         errorLog("Action page/ get action list error",error);
-        return of(fetchRejected(error.response, { status: error.status }))
+        return of(fetchRejected(dataInitState.payload, { status: error }))
       })
     )
   }),


### PR DESCRIPTION
Updated actions list page to show "No actions found" message on timeout rather than reload button. This is to avoid the issue where using a smart contract with no actions as a filter would always time out but users were encouraged to keep reloading.