### PR TITLE
Disabled button for hardcoded eosio account using our tool

### DIFF
--- a/docs/guides/permissions/update_account.md
+++ b/docs/guides/permissions/update_account.md
@@ -12,6 +12,8 @@ In the Default Signature Account panel, you can see the list of accounts with pu
 
 After checking which account you want to update, click the "EDIT" button corresponding to that account.
 
+:warning: - The default `eosio` account created when initializing the blockchain using our tool cannot be edited.
+
 ## Updating Keys
 
 For instance, let us assume you want to update an account with the name `dragonfruit`. You would click the "EDIT" button corresponding to the `dragonfruit` account, which would take you to this panel:

--- a/src/pages/PermissionPage/components/Permissionlist/Permissionlist.jsx
+++ b/src/pages/PermissionPage/components/Permissionlist/Permissionlist.jsx
@@ -122,6 +122,19 @@ const Permissionlist = (props) => {
       });
   }
 
+  function isDefaultEosio (permissionList) {
+    let _accountNameOne = (permissionList[0]) ?
+      permissionList[0].account === 'eosio' : false;
+    let _accountNameTwo = (permissionList[1]) ?
+      permissionList[1].account === 'eosio' : false;
+    let _accountOneId = (permissionList[0]) ?
+      (permissionList[0]._id === '1' || permissionList[0]._id === '2') : false;
+    let _accountTwoId = (permissionList[1]) ?
+      (permissionList[1]._id === '1' || permissionList[1]._id === '2') : false;
+
+    return _accountNameOne && _accountNameTwo && _accountOneId && _accountTwoId;
+  }
+
   function containsOnlyActiveOrOwner (permissionList) {
     let _permissionOneCorrect = false;
     let _permissionTwoCorrect = false;
@@ -217,9 +230,13 @@ const Permissionlist = (props) => {
                                               <ButtonPrimary 
                                                     style={{float:'right', marginRight:'5%'}}
                                                     onClick={() => getKeysData(defaultAccountsList[account][0].account, list, "edit")}
+                                                    disabled={isDefaultEosio(defaultAccountsList[account])}
                                                     block
                                                     >
-                                                    Edit
+                                                    {
+                                                      (isDefaultEosio(defaultAccountsList[account])) ? 
+                                                        "Uneditable" : "Edit"
+                                                    }
                                                   </ButtonPrimary>
                                             </EditButtonCell>
                                           </tr>


### PR DESCRIPTION
Changes
---
* When the tool is the one to initialize the blockchain, using our specific chain ID, we provide a default `eosio` account for users to sign and do actions with. The 'edit' button in the manage accounts page for this account is now disabled and is labeled as "Uneditable." 