### PR TITLE
Fix problem where changing to mainnet/other connection and then changing back to local node did not update blockchain info

### DIFF
--- a/src/pages/InfoPage/components/Nodeswitch/Nodeswitch.jsx
+++ b/src/pages/InfoPage/components/Nodeswitch/Nodeswitch.jsx
@@ -138,7 +138,6 @@ const Nodeswitch = (props) => {
               props.connectReset();
               setValues(pathInitState);
               setKey(Date.now());
-              props.accountClear();
             }}
             >
             Are you sure you want to restart the Nodeos connection to its initial state? 

--- a/src/reducers/endpoint.js
+++ b/src/reducers/endpoint.js
@@ -68,7 +68,7 @@ const swapEpic = ( action$, state$ ) => action$.pipe(
 
 const resetEpic = ( action$, state$ ) => action$.pipe(
   ofType(CONNECT_RESET),
-  mapTo(connectStart(pathInitState.nodeos, pathInitState.mongodb)),
+  mapTo(connectSwitch(pathInitState.nodeos, pathInitState.mongodb)),
 );
 
 


### PR DESCRIPTION
When switching the connection to a different node (NOT a `nodeos` instance made by this tool) and then resetting the connection back to the local node, the blockchain information would not be immediately updated. This means the redux store contains the wrong chain ID, this is why the EOSIO account disappears when clicking "reset all permissions."

Fix:
* When resetting the connection, `get_info` will be invoked immediately and account clearing will take place via the Redux store instead of invoking it from the front-end. 

See ticket 3429