### PR TITLE
Fix typos in the CLI help messages for individual commands

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -41,7 +41,7 @@ COMPILER="$LOCALSERVICE/docker-eosio-cdt"
 ISDEV=false
 MAKESAMPLEDATA=false
 
-USAGE="Usage: $(basename "$0") [-dev] [-s] [--server-mode] (program to initialize eosio-explorer)
+USAGE="Usage: eosio-explorer init [-dev] [-s] [--server-mode] (program to initialize eosio-explorer)
 
 where:
     -dev, --develop     Starts the tool in development mode

--- a/scripts/pause_dockers.sh
+++ b/scripts/pause_dockers.sh
@@ -15,7 +15,7 @@ if [ -f "$APP/config.file.local" ]; then
   source $APP/config.file.local
 fi
 
-USAGE="Usage: $(basename "$0") (Pause any currently running Docker containers)"
+USAGE="Usage: eosio-explorer pause_dockers (Pause any currently running Docker containers)"
 
 # check for arguments
 for arg in $@

--- a/scripts/remove_dockers.sh
+++ b/scripts/remove_dockers.sh
@@ -43,7 +43,7 @@ EOSDOCKER="$DEPENDENCIES_ROOT/docker-eosio-nodeos"
 MONGODOCKER="$DEPENDENCIES_ROOT/docker-mongodb"
 COMPILER="$DEPENDENCIES_ROOT/api-eosio-compiler/docker-eosio-cdt"
 
-USAGE="Usage: $(basename "$0") (Remove any currently present Docker containers)"
+USAGE="Usage: eosio-explorer remove_dockers (Remove any currently present Docker containers)"
 
 # check for arguments
 for arg in $@

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -49,7 +49,7 @@ BUILDAPPLICATION=false
 MAKESAMPLEDATA=false
 SERVERMODE=false
 
-USAGE="Usage: $(basename "$0") [-dev] [-d] [-b] [-s] [--init] [--server-mode] (program to start eosio-explorer)
+USAGE="Usage: explorer-eosio start [-dev] [-d] [-b] [-s] [--init] [--server-mode] (program to start eosio-explorer)
 
 where:
     -dev, --develop     Starts the tool in development mode

--- a/scripts/start_gui.sh
+++ b/scripts/start_gui.sh
@@ -43,7 +43,7 @@ COMPILER="$DEPENDENCIES_ROOT/api-eosio-compiler"
 
 ISDEV=false
 CLEARBROWSERSTORAGE=false
-USAGE="Usage: $(basename "$0") [-dev] [--clear-browser-storage] (program to start eosio-explorer gui)
+USAGE="Usage: eosio-explorer start_gui [-dev] [--clear-browser-storage] (program to start eosio-explorer gui)
 
 where:
     -dev, --develop           Starts the tool in development mode


### PR DESCRIPTION
Changes
---
* The `-h` flag for the individual commands had incorrect `usage` statements which were written as `bash` files but have been corrected to `eosio-explorer <command>`. 