### PR TITLE
Added '0' to list of invalid numbers for account creation

### DIFF
--- a/src/pages/PermissionPage/components/CreateAccount/CreateAccount.jsx
+++ b/src/pages/PermissionPage/components/CreateAccount/CreateAccount.jsx
@@ -115,7 +115,7 @@ const CreateAccount = (props) => {
                         }
                         <FormText>
                           <strong>An EOSIO account name cannot contain capital letters.
-                          It also cannot contain the numbers 6, 7, 8 or 9. The only special character you can use is '.'</strong>
+                          It also cannot contain the numbers 0, 6, 7, 8 or 9. The only special character you can use is '.'</strong>
                         </FormText>
                       </Col>
                     </FormGroup>


### PR DESCRIPTION
0 is also an invalid number to use for account name but it is not included in the instructions. 