### PR TITLE
Fogbugz 3443 - In production mode, serve the app to user without building GUI while init

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,16 +164,20 @@ Commands:
                     -dev / --develop - Starts the tool in development mode
                     -s / --sample-data - Starts the tool with pre-existing sample accounts
                                          and smart contracts
+                    -b / --build - Force building the gui of the tool
   start             Start the tool, assumes the dependencies and Docker images are already prepared
                     Available flags:
                     --server-mode - Starts the blockchain environment for the tool without
                                     opening the web application
                     -dev / --develop - Starts the tool in development mode
-                    -d / --delete - Removes existing Docker containers
-                    --init - Builds a production-ready version of the web tool,
-                             and opens the tool with cleared local storage
                     -s / --sample-data - Starts the tool with pre-existing
                                          sample accounts and smart contracts
+                    -d / --delete - Removes existing Docker containers
+                    -b / --build - Force building the gui of the tool
+                    --init - Builds a production-ready version of the web tool,
+                             and opens the tool with cleared local storage
+                    --no-timestamp - Builds gui without adding env LASTTIMESTAMP.
+                                     Should only used by developer right before making a release
   start_gui         Starts the web tool locally without touching the nodeos and MongoDB containers.
                     Available flags:
                     -dev / --develop - Starts the tool in development mode

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "express": "^4.16.4",
     "font-awesome": "^4.7.0",
     "http-proxy-middleware": "^0.19.1",
+    "js-cookie": "^2.2.0",
     "monaco-editor-webpack-plugin": "^1.7.0",
     "node-sass": "^4.11.0",
     "pm2": "^3.5.0",
@@ -64,6 +65,7 @@
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject",
     "serve": "node pm2.js",
+    "serve-clear": "CLEARBROWSERSTORAGE=true node pm2.js",
     "eosio-explorer": "./cli.sh"
   },
   "browserslist": [

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -128,7 +128,7 @@ echo "=============================="
 ./remove_dockers.sh
 
 # start the dockers and gui
-./start.sh $@ --init
+./start.sh $@ --clear-browser-storage
 
 P1=$!
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -46,6 +46,7 @@ USAGE="Usage: eosio-explorer init [-dev] [-s] [--server-mode] (program to initia
 where:
     -dev, --develop     Starts the tool in development mode
     -s, --sample-data   Starts the tool with pre-existing sample accounts and smart contracts
+    -b, --build         Build gui
     --server-mode       Starts the tool in server-mode, it will start the dockers but not the gui"
 
 # check for arguments
@@ -60,6 +61,9 @@ do
       ;;
     --server-mode)
       echo "Running the tool in server mode"
+      ;;
+    -b|--build)
+      echo "Running the tool with building gui"
       ;;
     -h|--help)
       echo "$USAGE"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -44,7 +44,7 @@ MONGODOCKER="$DEPENDENCIES_ROOT/docker-mongodb"
 
 ISDEV=false
 ISDELETE=false
-ISINIT=false
+CLEARBROWSERSTORAGE=false
 BUILDAPPLICATION=false
 MAKESAMPLEDATA=false
 SERVERMODE=false
@@ -54,13 +54,13 @@ NOTIMESTAMP=false
 USAGE="Usage: eosio-explorer start [-dev] [-d] [-b] [-s] [--init] [--server-mode] (program to start eosio-explorer)
 
 where:
-    -dev, --develop     Starts the tool in development mode
-    -d, --delete        Removes existing Docker containers
-    -b, --build         Build gui
-    -s, --sample-data   Starts the tool with pre-existing sample accounts and smart contracts
-    --init              Opens the tools with cleared local storage
-    --server-mode       Starts the tool in server-mode, it will start the dockers but not the gui
-    --no-timestamp      Builds gui without adding env LASTTIMESTAMP. Should only used by developer right before making a release"
+    -dev, --develop         Starts the tool in development mode
+    -d, --delete            Removes existing Docker containers
+    -b, --build             Build gui
+    -s, --sample-data       Starts the tool with pre-existing sample accounts and smart contracts
+    --clear-browser-storage Starts the tool with clearing browser local storage
+    --server-mode           Starts the tool in server-mode, it will start the dockers but not the gui
+    --no-timestamp          Builds gui without adding env LASTTIMESTAMP. Should only used by developer right before making a release"
 
 
 # check for arguments
@@ -74,8 +74,8 @@ do
     -dev|--develop)
       ISDEV=true
       ;;
-    --init)
-      ISINIT=true
+    --clear-browser-storage)
+      CLEARBROWSERSTORAGE=true
       ;;
     -s|--sample-data)
       MAKESAMPLEDATA=true
@@ -181,15 +181,15 @@ if ( ! $SERVERMODE ); then
 
   # build and start the application
   if $ISDEV; then
-    # If there is -d or from init setup, clear the browser storage by adding a new timestamp when start CRA dev.
-    if ($ISDELETE || $ISINIT); then
+    # If there is -d or from init setup ( or clear browser storage ), clear the browser storage by adding a new timestamp when start CRA dev.
+    if ($ISDELETE || $CLEARBROWSERSTORAGE); then
       ./start_gui.sh -dev --clear-browser-storage
     else
       ./start_gui.sh -dev
     fi
   else
-    # If this is from init setup, clear the browser storage by setting CLEARBROWSERSTORAGE=true while serve.
-    if $ISINIT; then
+    # If this is from init setup ( or clear browser storage ), clear the browser storage by setting CLEARBROWSERSTORAGE=true while serve.
+    if $CLEARBROWSERSTORAGE; then
       ./start_gui.sh --clear-browser-storage
     else
       ./start_gui.sh

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -49,17 +49,18 @@ BUILDAPPLICATION=false
 MAKESAMPLEDATA=false
 SERVERMODE=false
 HARDREPLAY=false
+NOTIMESTAMP=false
 
 USAGE="Usage: eosio-explorer start [-dev] [-d] [-b] [-s] [--init] [--server-mode] (program to start eosio-explorer)
 
 where:
     -dev, --develop     Starts the tool in development mode
     -d, --delete        Removes existing Docker containers
-    -b, --build         Re-build gui
+    -b, --build         Build gui
     -s, --sample-data   Starts the tool with pre-existing sample accounts and smart contracts
-    --init              Builds a production-ready version of the web tool,
-                          and opens the tool with cleared local storage
-    --server-mode       Starts the tool in server-mode, it will start the dockers but not the gui"
+    --init              Opens the tools with cleared local storage
+    --server-mode       Starts the tool in server-mode, it will start the dockers but not the gui
+    --no-timestamp      Builds gui without adding env LASTTIMESTAMP. Should only used by developer right before making a release"
 
 
 # check for arguments
@@ -88,6 +89,9 @@ do
     --hard-replay)
       HARDREPLAY=true
       ;;
+    --no-timestamp)
+      NOTIMESTAMP=true
+      ;;
     -h|--help)
       echo "$USAGE"
       exit
@@ -101,12 +105,11 @@ do
 done
 
 # If either of these conditions are true:
-#   init is being run
 #   user has not added -dev flag but:
 #     has added -d flag
 #     the build folder does not exist
 # Then build with a new timestamp.
-if ( $ISINIT || (!($ISDEV) && ($ISDELETE || [ ! -e $APP"/build" ])) ); then
+if (!($ISDEV) && ($ISDELETE || [ ! -e $APP"/build" ])); then
   BUILDAPPLICATION=true
 fi
 
@@ -165,19 +168,32 @@ if ( ! $SERVERMODE ); then
     echo "=============================="
 
     # Set environment variable "REACT_APP_LAST_INIT_TIMESTAMP" at build time to create a new timestamp while serving the app.
-    (cd $APP && REACT_APP_LAST_INIT_TIMESTAMP=$(date +%s) yarn build && printf "${GREEN}done${NC}")
+    if ( ! $NOTIMESTAMP ); then
+      (cd $APP && REACT_APP_LAST_INIT_TIMESTAMP=$(date +%s) yarn build && printf "${GREEN}done${NC}")
+    else
+      # Build without timestamp, this should only be used right before we are doing a release by publishing the build folder to npm
+
+      echo "You are building gui without a last timestamp!"
+      echo " "
+      (cd $APP && yarn build && printf "${GREEN}done${NC}")
+    fi
   fi
 
   # build and start the application
-  # If there is -d or from init setup, clear the browser storage by adding a new timestamp when start CRA dev.
   if $ISDEV; then
+    # If there is -d or from init setup, clear the browser storage by adding a new timestamp when start CRA dev.
     if ($ISDELETE || $ISINIT); then
       ./start_gui.sh -dev --clear-browser-storage
     else
       ./start_gui.sh -dev
     fi
   else
-    ./start_gui.sh
+    # If this is from init setup, clear the browser storage by setting CLEARBROWSERSTORAGE=true while serve.
+    if $ISINIT; then
+      ./start_gui.sh --clear-browser-storage
+    else
+      ./start_gui.sh
+    fi
   fi
 else
   echo ""

--- a/scripts/start_gui.sh
+++ b/scripts/start_gui.sh
@@ -47,7 +47,7 @@ USAGE="Usage: eosio-explorer start_gui [-dev] [--clear-browser-storage] (program
 
 where:
     -dev, --develop           Starts the tool in development mode
-    --clear-browser-storage   Clears the local storage"
+    --clear-browser-storage   Starts the tool with clearing browser local storage"
 
 
 # check for arguments

--- a/scripts/start_gui.sh
+++ b/scripts/start_gui.sh
@@ -96,5 +96,10 @@ if $ISDEV; then
     (cd $APP && PORT=$APP_DEV_PORT yarn start)
   fi
 else
+  # run yarn serve-clear to adding env CLEARBROWSERSTORAGE=true while starting to serve
+  if $CLEARBROWSERSTORAGE; then
+    (cd $APP && yarn serve-clear $COMPILER)
+  else
     (cd $APP && yarn serve $COMPILER)
+  fi
 fi

--- a/serve.js
+++ b/serve.js
@@ -18,6 +18,16 @@ if (envConfig){
 
 const PORT = process.env.REACT_APP_APP_SERVE_PORT;
 
+// If serve.js is called from yarn serve-clear, set lastTimestamp = current timestamp
+const lastTimestamp = process.env.CLEARBROWSERSTORAGE ? Math.floor(new Date() / 1000) : "";
+
+app.use((req, res, next) => {
+
+  // Always assign a value to the lastTimestamp cookie, either current timestamp or an empty string.
+  res.cookie("lastTimestamp", lastTimestamp );
+  next();
+});
+
 //only serve api calls ( not the static build/ ) in development mode, create react app in develop will call the APIs from a proxy.
 if ( process.env.MODE !== 'development'){
   app.use(express.static(path.join(__dirname, 'build')));

--- a/src/index.js
+++ b/src/index.js
@@ -3,19 +3,21 @@ import { hydrate, render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
 import { PersistGate } from 'redux-persist/integration/react'
+import Cookies from 'js-cookie';
 
 import store, { history, persistor } from 'store';
 import App from 'app';
 
-const currentLastTimestamp = process.env.REACT_APP_LAST_INIT_TIMESTAMP;
+// Set the current timestamp from cookie -> process.env -> default empty
+const currentLastTimestamp = Cookies.get('lastTimestamp') || process.env.REACT_APP_LAST_INIT_TIMESTAMP || "";
 
-// If currentLastTimestamp is not defined, current application run must not start from a init script.
+// If currentLastTimestamp is empty, current application run does not need to clear local storage.
 // Hence, ignore below steps for not clearing persisted store and not setting local storage variable.
 if ( currentLastTimestamp ){
 
   const storedLastTimestamp = localStorage.getItem('lastTimestamp');
 
-  // If the current last timestamp from process.env does not match the stored one, it means user has run init
+  // If the current last timestamp from cookies / process.env does not match the stored one, it means user has run init or has built the app again
   // Hence, clear the whole persisted store.
   if ( currentLastTimestamp !== storedLastTimestamp ){
     persistor.purge();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6649,6 +6649,11 @@ js-base64@^2.1.8:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
   integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
+js-cookie@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
+  integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
+
 js-git@^0.7.8:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/js-git/-/js-git-0.7.8.tgz#52fa655ab61877d6f1079efc6534b554f31e5444"


### PR DESCRIPTION
Enhance:
1. To fix the potential dependency not matching issue when we global install the app ( react-scripts v3 reach hook lint break the build )
2. To boost the time for user doing first time setup
3. To reduce the complexity of supporting multi OS support in production mode because all things we serve should be just static files
4. ​Let production mode stay with a deterministic version of built code

Done:
1. Skip building the app while user run init.
2. Use cookie to apply clear local storage feature without building the app while init.
3. Provide new option --no-timestamp for building the app without a last timestamp for publish a release.
4. Update documentation.