### PR TITLE
Fogbugz 3431 - Action history loading spinner

### DIFF
--- a/src/pages/PushactionPage/PushactionPageReducer.js
+++ b/src/pages/PushactionPage/PushactionPageReducer.js
@@ -264,7 +264,7 @@ const dataReducer = (state = dataInitState, action) => {
 };
 
 // Handles loading state
-const isFetchingReducer = (state = false, action) => {
+const isFetchingActionHistoryReducer = (state = false, action) => {
   switch (action.type) {
     case FETCH_START:
       return true;
@@ -394,7 +394,7 @@ const filterReducer = (state = filterInitState, action) => {
 
 export const combinedReducer = combineReducers({
   data: dataReducer,
-  isFetching: isFetchingReducer,
+  isFetchingActionHistory: isFetchingActionHistoryReducer,
   actionId: actionIdReducer,
   action: actionReducer,
   isPushingAction: isPushingActionReducer,

--- a/src/pages/PushactionPage/components/Actionhistory.jsx
+++ b/src/pages/PushactionPage/components/Actionhistory.jsx
@@ -54,7 +54,7 @@ const dropdownMaxHeight = {
 
 const Actionhistory = (props) => {
 
-  let { pushactionPage: { isFetching, data: { actionsList = [] }, records, filter, smartContracts: { smartContractsList = [] } } } = props;
+  let { pushactionPage: { isFetchingActionHistory, data: { actionsList = [] }, records, filter, smartContracts: { smartContractsList = [] } } } = props;
 
   const [isOpenDropDownSmartContract, toggleDropDownSmartContract] = useState(false);
 
@@ -62,9 +62,6 @@ const Actionhistory = (props) => {
     <div className="Actionhistory">
       <Row>
         <Col xs="12">
-        { isFetching ? (
-          <LoadingSpinner />
-        ) : (
           <Row>
             <ColStyled xs="3">
               <CustomDropdown id="SmartContractFilterDropdown" isOpen={isOpenDropDownSmartContract} toggle={() => { toggleDropDownSmartContract(!isOpenDropDownSmartContract) }}>
@@ -98,7 +95,9 @@ const Actionhistory = (props) => {
                   </tr>
                 </thead>
                 <tbody>
-                  {actionsList.length < 1 ?
+                  { isFetchingActionHistory ?
+                    <tr><td colSpan="5" className="text-center"><LoadingSpinner /></td></tr>
+                  : actionsList.length < 1 ?
                     <tr><td colSpan="5" className="text-center">No actions found{filter.smartContractName && ` with Smart Contract name ${filter.smartContractName}` }</td></tr>
                   : actionsList.map((action, index)=>
                     <tr key={index} data-globalsequence={action.receipt.global_sequence}>
@@ -116,7 +115,6 @@ const Actionhistory = (props) => {
               </TableStyledNoPointer>
             </Col>            
           </Row>
-        )}
         </Col>
       </Row>
     </div>

--- a/src/pages/PushactionPage/components/Actionhistory.jsx
+++ b/src/pages/PushactionPage/components/Actionhistory.jsx
@@ -69,7 +69,7 @@ const Actionhistory = (props) => {
                 <DropdownMenu modifiers={dropdownMaxHeight}>
                   {smartContractsList &&
                     (smartContractsList).map((smartContract) =>
-                      <DropdownItem key={smartContract._id} onClick={(e) => { props.filterUpdate({ smartContractName: smartContract.name }); }}>
+                      <DropdownItem key={smartContract._id} onClick={(e) => { (smartContract.name !== filter.smartContractName) && props.filterUpdate({ smartContractName: smartContract.name }); }}>
                         {smartContract.name}
                       </DropdownItem>)}
                 </DropdownMenu>


### PR DESCRIPTION
In the Action History section of Push Action page, the loading spinner has been moved inside the table so that the filter & records selector are always visible.