### PR TITLE
Fogbugz 3419 - Error Console going off screen

### DIFF
--- a/src/components/ConsoleLogger/ConsoleLogger.scss
+++ b/src/components/ConsoleLogger/ConsoleLogger.scss
@@ -6,6 +6,7 @@
   bottom: -600px;
   z-index: 2;
   &.open{
+    max-height: calc(100vh - 80px);
     bottom: 0;
   }
   &.close{


### PR DESCRIPTION
Gave error console a max height of 100% of viewport height - 80px (height of the header) to avoid the error console going off screen on small screen heights.