### PR TITLE
Adjustments to in-app console log terminal

### DIFF
--- a/src/components/ConsoleLogger/ConsoleLogger.jsx
+++ b/src/components/ConsoleLogger/ConsoleLogger.jsx
@@ -39,7 +39,6 @@ class ConsoleLogger extends Component {
    */
   handleClickOutside(event) {
     if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
-      // alert('You clicked outside of me!');
       this.props.panelSet("UNOPEN");
     }
   }
@@ -50,7 +49,6 @@ class ConsoleLogger extends Component {
 
     return (
       <div ref={this.setWrapperRef} className={`ConsoleLogger ${ status.toLowerCase() }`}>
-
         <CardHeaderStyled
           className="console-title"
           onClick={()=>{

--- a/src/components/ConsoleLogger/ConsoleLogger.jsx
+++ b/src/components/ConsoleLogger/ConsoleLogger.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import Terminal from 'terminal-in-react';
 import { CardHeaderStyled } from 'styled';
 
-import { panelSet } from 'reducers/errorlog';
+import { panelSet, logReset } from 'reducers/errorlog';
 
 class ConsoleLogger extends Component {
 
@@ -17,12 +17,14 @@ class ConsoleLogger extends Component {
     this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
-
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClickOutside);
   }
 
   componentWillUnmount() {
+    if (this.props.errorlog.data.unseen > 0) {
+      this.props.logReset();
+    }
     document.removeEventListener('mousedown', this.handleClickOutside);
   }
   /**
@@ -91,6 +93,7 @@ export default connect(
   }),
   {
     panelSet,
+    logReset,
   }
 
 )(ConsoleLogger);

--- a/src/helpers/error-logger.js
+++ b/src/helpers/error-logger.js
@@ -2,6 +2,8 @@ import store from 'store';
 import { logStart } from 'reducers/errorlog';
 
 export const errorLog = (...obj) => {
-  store.dispatch(logStart());
-  console.log([...obj, new Date()]);
+  if (obj) {
+    store.dispatch(logStart());
+    console.log([...obj, new Date()]);
+  }
 }


### PR DESCRIPTION
Changes
---
* Added a new behavior to the in-app console log: The badge containing the number of unseen messages will be reset when navigating to another page, since these messages are tied to the developer tool console. The developer tool console clears every time you navigate to a new page, but the badge does not get reset.
* Added a check to the helper function that dispatches the log open action: To ensure the console log does not randomly appear even if there are no visible events in the developer console, the function now checks if an error object and/or message have been passed to the function. If nothing has been passed to this helper function, the helper function does nothing. 