### PR TITLE
Fix a bug where calling eosio-explorer start right after eosio-explorer init would clear the local storage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ if ( currentLastTimestamp ){
 
   // If the current last timestamp from cookies / process.env does not match the stored one, it means user has run init or has built the app again
   // Hence, clear the whole persisted store.
-  if ( currentLastTimestamp !== storedLastTimestamp ){
+  if ( currentLastTimestamp !== storedLastTimestamp && storedLastTimestamp < currentLastTimestamp){
     persistor.purge();
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,10 @@ if ( currentLastTimestamp ){
 
   const storedLastTimestamp = localStorage.getItem('lastTimestamp');
 
-  // If the current last timestamp from cookies / process.env does not match the stored one, it means user has run init or has built the app again
+  // If the current last timestamp from cookies / process.env is greater than the stored one, it means user has run init or has built the app again
+  // since the last initialization or build.
   // Hence, clear the whole persisted store.
-  if ( currentLastTimestamp !== storedLastTimestamp && storedLastTimestamp < currentLastTimestamp){
+  if (storedLastTimestamp < currentLastTimestamp){
     persistor.purge();
   }
 


### PR DESCRIPTION
If you initialize the site:

`(yarn) eosio-explorer init [-b]`

Then, you stop your session and then resume it:

`(yarn) eosio-explorer start`

The result ends up that your local storage would be cleared. This is due to timestamp assignment, the tool makes use of timestamps to determine whether to clear the local storage or not. We should only clear the local storage if the timestamp stored is earlier than the current date, but under this specific case, the stored timestamp is after the current date, which the logic didn't seem to account for. This PR fixes that issue 